### PR TITLE
GPIO API

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -16,14 +16,31 @@
  ******************************************************************************
  */
 
-#include <stdint.h>
+#include "stm32f1xx.h"
 
-#if !defined(__SOFT_FP__) && defined(__ARM_FP)
-  #warning "FPU is not initialized, but the project is compiling for an FPU. Please initialize the FPU before use."
-#endif
 
-int main(void)
-{
-    /* Loop forever */
-	for(;;);
+void delay(void){
+	for(uint32_t i = 0; i < 500000/2; i ++);
+}
+
+int main(void){
+	GPIO_Handle_t  GpioLed;
+
+	// lets make a handler
+	GpioLed.pGPIOx = GPIOC;
+	GpioLed.GPIO_PinConfig.GPIO_PinNumber = GPIO_PIN_NO_13;
+	GpioLed.GPIO_PinConfig.GPIO_PinMode = GPIO_MODE_OUT_PP;
+	GpioLed.GPIO_PinConfig.GPIO_PinDirection = GPIO_DIR_OUT_MEDIUM;
+
+	//Enable the clock for port D
+	GPIO_PCLK_CTRL(GPIOD, ENABLE);
+	//init the pin with the above handler
+	GPIO_Init(&GpioLed);
+
+	while(1){
+		GPIO_ToggleOutputPin(GPIOD, GPIO_PIN_NO_12);
+		delay();
+	}
+
+	return 0;
 }

--- a/Src/main.c
+++ b/Src/main.c
@@ -32,13 +32,13 @@ int main(void){
 	GpioLed.GPIO_PinConfig.GPIO_PinMode = GPIO_MODE_OUT_PP;
 	GpioLed.GPIO_PinConfig.GPIO_PinDirection = GPIO_DIR_OUT_MEDIUM;
 
-	//Enable the clock for port D
-	GPIO_PCLK_CTRL(GPIOD, ENABLE);
+	//Enable the clock for port C
+	GPIO_PCLK_CTRL(GPIOC, ENABLE);
 	//init the pin with the above handler
 	GPIO_Init(&GpioLed);
 
 	while(1){
-		GPIO_ToggleOutputPin(GPIOD, GPIO_PIN_NO_12);
+		GPIO_ToggleOutputPin(GPIOC, GPIO_PIN_NO_13);
 		delay();
 	}
 

--- a/drivers/Inc/stm32f103xx_gpio.h
+++ b/drivers/Inc/stm32f103xx_gpio.h
@@ -1,0 +1,91 @@
+/*
+ * stm32f103xx_gpio.h
+ *
+ *  Created on: Nov 19, 2023
+ *      Author: zaccko
+ */
+
+#ifndef INC_STM32F103XX_GPIO_H_
+#define INC_STM32F103XX_GPIO_H_
+
+#include "stm32f1xx.h"
+
+typedef struct
+{
+	uint8_t GPIO_PinDirection;
+	uint8_t GPIO_PinNumber;
+	uint8_t GPIO_PinMode;
+	uint8_t GPIO_PinSpeed;
+	uint8_t GPIO_PuPdControl;
+	uint8_t GPIO_PinOpType;
+	uint8_t GPIO_PinAltFunMode;
+}GPIO_PinConfig_t;
+
+
+typedef struct
+{
+	GPIO_RegDef_t *pGPIOx;
+	GPIO_PinConfig_t GPIO_PinConfig;
+}GPIO_Handle_t;
+
+
+/* GPIO APIs */
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle);
+void GPIO_DeInit(GPIO_RegDef_t *pGPIOHandle);
+
+//clock set up for GPIO
+void GPIO_PCLK_CTRL(GPIO_RegDef_t *pGPIOx, uint8_t EnorDi);
+
+//Data Read and Write
+//Data Read and Write
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+uint16_t GPIO_ReadFromInputPort(GPIO_RegDef_t *pGPIOx);
+void GPIO_WriteToOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber, uint8_t value);
+void GPIO_WriteToOutputPort(GPIO_RegDef_t *pGPIOx, uint16_t value);
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber);
+
+//IRQ config and ISR handling
+void GPIO_IRQConfig(uint8_t IRQNumber, uint8_t IRQPriority, uint8_t EnorDi);
+void GPIO_IRQHandling(uint8_t PinNumber);
+
+
+// MACROS
+// GPIO INPUT TYPES MACROS
+#define GPIO_MODE_IN_AN 	0
+#define GPIO_MODE_IN_FP 	1
+#define GPIO_MODE_IN_PUPD	2
+
+// GPIO OUTPUT TYPES MACROS
+#define GPIO_MODE_OUT_PP 	0
+#define GPIO_MODE_OUT_OD 	1
+
+//SPEED MACROS
+#define GPIO_SPEED_LOW 1
+#define GPIO_SPEED_MEDIUM 2
+#define GPIO_SPEED_FAST 3
+
+// GPIO DIRECTION TYPES
+#define GPIO_DIRECTION_IN	0
+#define GPIO_DIRECTION_OUT	1
+
+
+//pin Number macros
+#define GPIO_PIN_NO_0 0
+#define GPIO_PIN_NO_1 1
+#define GPIO_PIN_NO_2 2
+#define GPIO_PIN_NO_3 3
+#define GPIO_PIN_NO_4 4
+#define GPIO_PIN_NO_5 5
+#define GPIO_PIN_NO_6 6
+#define GPIO_PIN_NO_7 7
+#define GPIO_PIN_NO_8 8
+#define GPIO_PIN_NO_9 9
+#define GPIO_PIN_NO_10 10
+#define GPIO_PIN_NO_11 11
+#define GPIO_PIN_NO_12 12
+#define GPIO_PIN_NO_13 13
+#define GPIO_PIN_NO_14 14
+#define GPIO_PIN_NO_15 15
+
+
+#endif /* INC_STM32F103XX_GPIO_H_ */

--- a/drivers/Inc/stm32f103xx_gpio.h
+++ b/drivers/Inc/stm32f103xx_gpio.h
@@ -15,7 +15,6 @@ typedef struct
 	uint8_t GPIO_PinDirection;
 	uint8_t GPIO_PinNumber;
 	uint8_t GPIO_PinMode;
-	uint8_t GPIO_PinSpeed;
 	uint8_t GPIO_PuPdControl;
 	uint8_t GPIO_PinOpType;
 	uint8_t GPIO_PinAltFunMode;
@@ -59,14 +58,13 @@ void GPIO_IRQHandling(uint8_t PinNumber);
 #define GPIO_MODE_OUT_PP 	0
 #define GPIO_MODE_OUT_OD 	1
 
-//SPEED MACROS
-#define GPIO_SPEED_LOW 1
-#define GPIO_SPEED_MEDIUM 2
-#define GPIO_SPEED_FAST 3
+//DIRECTION & SPEED MACROS
+#define GPIO_DIR_IN				0
+#define GPIO_DIR_OUT_LOW 		1
+#define GPIO_DIR_OUT_MEDIUM 	2
+#define GPIO_DIR_OUT_FAST 		3
 
-// GPIO DIRECTION TYPES
-#define GPIO_DIRECTION_IN	0
-#define GPIO_DIRECTION_OUT	1
+
 
 
 //pin Number macros

--- a/drivers/Inc/stm32f1xx.h
+++ b/drivers/Inc/stm32f1xx.h
@@ -50,7 +50,7 @@
 #define UART5_BASEADDR		(APB1PERIPH_BASE + 0x5000)
 
 //AHB Peripherals
-#define RCC_BASEADDR 		(AHBPERIPH_BASE + 0x1000)
+#define RCC_BASEADDR 		(AHBPERIPH_BASE + 0x9000)
 
 //Peripheral Register structs
 

--- a/drivers/Inc/stm32f1xx.h
+++ b/drivers/Inc/stm32f1xx.h
@@ -119,6 +119,16 @@ typedef struct
 #define GPIOG_PCLK_DI()		(RCC->APB2ENR &= ~(1 << 8))
 
 
+// GPIO REGISTER RESET MACROS
+#define GPIOA_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 2)); (RCC->APB2RSTR &= ~(1 << 2));} while (0)
+#define GPIOB_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 3)); (RCC->APB2RSTR &= ~(1 << 3));} while (0)
+#define GPIOC_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 4)); (RCC->APB2RSTR &= ~(1 << 4));} while (0)
+#define GPIOD_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 5)); (RCC->APB2RSTR &= ~(1 << 5));} while (0)
+#define GPIOE_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 6)); (RCC->APB2RSTR &= ~(1 << 6));} while (0)
+#define GPIOF_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 7)); (RCC->APB2RSTR &= ~(1 << 7));} while (0)
+#define GPIOG_REG_RESET()	do {(RCC->APB2RSTR |= (1 << 8)); (RCC->APB2RSTR &= ~(1 << 8));} while (0)
+
+
 
 // Conviniences
 #define ENABLE 1

--- a/drivers/Inc/stm32f1xx.h
+++ b/drivers/Inc/stm32f1xx.h
@@ -129,7 +129,7 @@ typedef struct
 #define GPIO_PIN_RESET RESET
 
 
-
+#include "stm32f103xx_gpio.h"
 
 
 

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -40,9 +40,9 @@ void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
 
 	// use CRH or CRL when setting direction and speed
 	if (pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber < 8) {
-		pGPIOHandle->pGPIOx->CRL = temp_reg_setting;
+		pGPIOHandle->pGPIOx->CRL |= temp_reg_setting;
 	} else {
-		pGPIOHandle->pGPIOx->CRH = temp_reg_setting;
+		pGPIOHandle->pGPIOx->CRH |= temp_reg_setting;
 	}
 
 	temp_reg_setting = 0;

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -28,10 +28,15 @@ void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
 
 	uint32_t temp_reg_setting = 0;
 
+	// set mode of pin
+	temp_reg_setting = (pGPIOHandle->GPIO_PinConfig.GPIO_PinMode << (2 + (4 * pin_port_pos)));
+
 
 	// set direction and speed of pin
+	if(pGPIOHandle->GPIO_PinConfig.GPIO_PinDirection > GPIO_DIR_IN){
 	temp_reg_setting = (pGPIOHandle->GPIO_PinConfig.GPIO_PinDirection
 			<< (4 * pin_port_pos));
+	}
 
 	// use CRH or CRL when setting direction and speed
 	if (pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber < 8) {
@@ -40,7 +45,9 @@ void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
 		pGPIOHandle->pGPIOx->CRH = temp_reg_setting;
 	}
 
-	// set mode of pin
+	temp_reg_setting = 0;
+
+
 
 }
 void GPIO_DeInit(GPIO_RegDef_t *pGPIOx) {

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -1,0 +1,123 @@
+/*
+ * stm32f103xx_gpio.c
+ *
+ *  Created on: Nov 20, 2023
+ *      Author: zaccko
+ */
+
+#include "stm32f103xx_gpio.h"
+
+/******
+ * @fn GPIO_INITL
+ *
+ * @brief  Enables or Disables clock for a GPIO Port
+ *
+ * @params[pGPIOx] port handle structure
+ *
+ * @return void
+ * @note
+ *  */
+void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
+	//pin port position
+	uint8_t pin_port_pos;
+	if (pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber < 8) {
+		pin_port_pos = pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber;
+	} else {
+		pin_port_pos = pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber - 8;
+	}
+
+	uint32_t temp_reg_setting = 0;
+
+
+	// set direction and speed of pin
+	temp_reg_setting = (pGPIOHandle->GPIO_PinConfig.GPIO_PinDirection
+			<< (4 * pin_port_pos));
+
+	// use CRH or CRL when setting direction and speed
+	if (pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber < 8) {
+		pGPIOHandle->pGPIOx->CRL = temp_reg_setting;
+	} else {
+		pGPIOHandle->pGPIOx->CRH = temp_reg_setting;
+	}
+
+	// set mode of pin
+
+}
+void GPIO_DeInit(GPIO_RegDef_t *pGPIOx) {
+
+}
+
+/******
+ * @fn GPIO_PCLK_CTRL
+ *
+ * @brief  Enables or Disables clock for a GPIO Port
+ *
+ * @params[pGPIOx] port base address
+ * @params[EnorDi] Enable or Disable MAcros from header
+ *
+ * @return void
+ * @note
+ *  */
+void GPIO_PCLK_CTRL(GPIO_RegDef_t *pGPIOx, uint8_t EnorDi) {
+	if (EnorDi == ENABLE) {
+		if (pGPIOx == GPIOA) {
+			GPIOA_PCLK_EN();
+		} else if (pGPIOx == GPIOB) {
+			GPIOB_PCLK_EN();
+		} else if (pGPIOx == GPIOC) {
+			GPIOC_PCLK_EN();
+		} else if (pGPIOx == GPIOD) {
+			GPIOD_PCLK_EN();
+		} else if (pGPIOx == GPIOE) {
+			GPIOE_PCLK_EN();
+		} else if (pGPIOx == GPIOF) {
+			GPIOF_PCLK_EN();
+		} else if (pGPIOx == GPIOG) {
+			GPIOG_PCLK_EN();
+		}
+	} else {
+		if (pGPIOx == GPIOA) {
+			GPIOA_PCLK_DI();
+		} else if (pGPIOx == GPIOB) {
+			GPIOB_PCLK_DI();
+		} else if (pGPIOx == GPIOC) {
+			GPIOC_PCLK_DI();
+		} else if (pGPIOx == GPIOD) {
+			GPIOD_PCLK_DI();
+		} else if (pGPIOx == GPIOE) {
+			GPIOE_PCLK_DI();
+		} else if (pGPIOx == GPIOF) {
+			GPIOF_PCLK_DI();
+		} else if (pGPIOx == GPIOG) {
+			GPIOG_PCLK_DI();
+		}
+	}
+
+}
+//Data Read and Write
+uint8_t GPIO_ReadFromInputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {
+
+	return 0;
+}
+uint16_t GPIO_ReadFromInputPort(GPIO_RegDef_t *pGPIOx) {
+	return 0;
+
+}
+void GPIO_WriteToOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber,
+		uint8_t value) {
+
+}
+void GPIO_WriteToOutputPort(GPIO_RegDef_t *pGPIOx, uint16_t value) {
+
+}
+void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {
+
+}
+
+//IRQ config and ISR handling
+void GPIO_IRQConfig(uint8_t IRQNumber, uint8_t IRQPriority, uint8_t EnorDi) {
+
+}
+void GPIO_IRQHandling(uint8_t PinNumber) {
+
+}

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -110,11 +110,40 @@ uint16_t GPIO_ReadFromInputPort(GPIO_RegDef_t *pGPIOx) {
 	return 0;
 
 }
+/******
+ * @fn GPIO_WriteToOutputPin
+ *
+ * @brief Writes a value to an output pin
+ *
+ * @params[pGPIOx] port base address
+ * @params[PinNumber] Pin Number to write to
+ * @params[value] value to write to the Pin
+ * @return none
+ * @note
+ *  */
 void GPIO_WriteToOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber,
-		uint8_t value) {
+		uint8_t Value) {
 
+	//based on set and reset macros
+	if(Value == GPIO_PIN_SET){
+		pGPIOx->ODR |= (1 << PinNumber);
+	}else{
+		pGPIOx->ODR &= ~(1 << PinNumber);
+
+	}
 }
-void GPIO_WriteToOutputPort(GPIO_RegDef_t *pGPIOx, uint16_t value) {
+/******
+ * @fn GPIO_WriteToOutputPin
+ *
+ * @brief Writes a value to an output port
+ *
+ * @params[pGPIOx] port base address
+ * @params[value] value to write to the Port
+ * @return none
+ * @note
+ *  */
+void GPIO_WriteToOutputPort(GPIO_RegDef_t *pGPIOx, uint16_t Value) {
+	pGPIOx->ODR = Value;
 
 }
 void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -133,7 +133,7 @@ void GPIO_WriteToOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber,
 	}
 }
 /******
- * @fn GPIO_WriteToOutputPin
+ * @fn GPIO_WriteToOutputPort
  *
  * @brief Writes a value to an output port
  *
@@ -146,7 +146,21 @@ void GPIO_WriteToOutputPort(GPIO_RegDef_t *pGPIOx, uint16_t Value) {
 	pGPIOx->ODR = Value;
 
 }
+
+/******
+ * @fn GPIO_ToggleOutputPin
+ *
+ * @brief Flips the value at a given output pin
+ *
+ * @params[pGPIOx] port base address
+ * @params[PinNumber] Pin Number to Flip
+ *
+ * @return none
+ * @note
+ *  */
 void GPIO_ToggleOutputPin(GPIO_RegDef_t *pGPIOx, uint8_t PinNumber) {
+	//use XOR to toggle bitfield
+		pGPIOx->ODR = pGPIOx ->ODR ^ (1 << PinNumber);
 
 }
 

--- a/drivers/src/stm32f103xx_gpio.c
+++ b/drivers/src/stm32f103xx_gpio.c
@@ -51,7 +51,21 @@ void GPIO_Init(GPIO_Handle_t *pGPIOHandle) {
 
 }
 void GPIO_DeInit(GPIO_RegDef_t *pGPIOx) {
-
+	if (pGPIOx == GPIOA) {
+			GPIOA_REG_RESET();
+		} else if (pGPIOx == GPIOB) {
+			GPIOB_REG_RESET();
+		} else if (pGPIOx == GPIOC) {
+			GPIOC_REG_RESET();
+		} else if (pGPIOx == GPIOD) {
+			GPIOD_REG_RESET();
+		} else if (pGPIOx == GPIOE) {
+			GPIOE_REG_RESET();
+		} else if (pGPIOx == GPIOF) {
+			GPIOF_REG_RESET();
+		} else if (pGPIOx == GPIOG) {
+			GPIOG_REG_RESET();
+		}
 }
 
 /******


### PR DESCRIPTION
Structs to Blinking LED 


What We have
Hardware
- STM32F103C8T6
- ST Link V2 

Software
- STIDE 
- Code with 
    - Memory Regions 
    - Bus Domains and Memory Boundaries
    - Peripheral Base Addresses 
    - MCU Header with GPUO, RCC  Register Structs 


What we want
- An application that blinks the onboard LED  to achieve this we need to be able to set the states of the Port c pin 13 to high and low. 

What we need to do  to achieve the above 
- [x] Define enable and disable macros for GPIO on the mcc header file
- [x] Add gpio header file and define the following  
    - [x] Struct with  mode ,number, speed, pups status, output type
    - [x] Function declarations for init, deinit, clock control , write to pin , toggle pin 
A gpio source file, with function definitions for the above declarations (refer for manual for)
       - [x]  init 
       - [ ]  deinit
       - [x]  togglepin

     
- A main source file 
    - Enable the gpio clock
    - Init gpio
    - Loop while toggling pin c 13

# Resources 
Section 9.2.1  of 
[Bluepill_ref_manual.pdf](https://github.com/zacck/stm32f1xx_drivers/files/13797565/Bluepill_ref_manual.pdf) describes how to set this up

